### PR TITLE
Add compatibility for Chunk-Pregenerator

### DIFF
--- a/src/main/java/org/dimdev/jeid/mixin/core/world/MixinChunk.java
+++ b/src/main/java/org/dimdev/jeid/mixin/core/world/MixinChunk.java
@@ -10,7 +10,9 @@ import org.spongepowered.asm.mixin.Dynamic;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Constant;
 import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.ModifyConstant;
 import org.spongepowered.asm.mixin.injection.ModifyVariable;
 import org.spongepowered.asm.mixin.injection.Redirect;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
@@ -50,11 +52,20 @@ public class MixinChunk implements INewChunk {
         cir.setReturnValue(arr);
     }
 
-    // TODO: might want to change getBiome a bit - see issue #14
     @Dynamic("Read biome id from int biome array to int k")
     @ModifyVariable(method = "getBiome", at = @At(value = "STORE", ordinal = 0), name = "k")
     private int reid$fromIntBiomeArray(int original, @Local(name = "i") int i, @Local(name = "j") int j) {
         return this.intBiomeArray[j << 4 | i];
+    }
+
+    /**
+     * Compatibility for mods that don't initialize the chunk's biome array on generation (e.g. Chunk-Pregenerator)
+     *
+     * @reason Use intBiomeArray's default value.
+     */
+    @ModifyConstant(method = "getBiome", constant = @Constant(intValue = 255, ordinal = 1))
+    private int reid$modifyDefaultId(int original) {
+        return -1;
     }
 
     @Inject(method = "getBiome", at = @At(value = "INVOKE_ASSIGN", target = "Lnet/minecraft/world/biome/Biome;getIdForBiome(Lnet/minecraft/world/biome/Biome;)I"))

--- a/src/main/java/org/dimdev/jeid/mixin/core/world/MixinChunkProviderServer.java
+++ b/src/main/java/org/dimdev/jeid/mixin/core/world/MixinChunkProviderServer.java
@@ -26,7 +26,8 @@ public class MixinChunkProviderServer {
     public WorldServer world;
 
     /**
-     * @reason Return an empty biome byte array if the chunk is using an int biome array.
+     * @reason Initialize biome array after any calls to {@link net.minecraft.world.gen.IChunkGenerator#generateChunk}.
+     * This guarantees the correct biomes even for modded chunk generators.
      */
     @Inject(method = "provideChunk", at = @At(value = "INVOKE_ASSIGN", target = "Lnet/minecraft/world/gen/IChunkGenerator;generateChunk(II)Lnet/minecraft/world/chunk/Chunk;"))
     private void reid$initializeBiomeArray(int x, int z, CallbackInfoReturnable<Chunk> cir, @Local Chunk chunk) {


### PR DESCRIPTION
Seems like a relatively simple fix, should mean the Chunk-Pregenerator mod is compatible now. This is the only mod that I'm aware of that triggers the associated if block, that is: 
>if getBiome is called before the biome array is initialised the provider is queried to find the expected biome.

(taken from https://github.com/DimensionalDevelopment/JustEnoughIDs/issues/42#issuecomment-520286560)
Tested seed `-107391545297039861` on SP and the pregenerated chunks from Chunk-Pregenerator seem to have the correct biome now. Fixes #14, #40, DimensionalDevelopment/JustEnoughIDs#42.