### PR TITLE
Fix biome change rendering client-side and BiomeArrayMessage handling

### DIFF
--- a/src/main/java/org/dimdev/jeid/mixin/modsupport/biometweaker/MixinCommandSetBiome.java
+++ b/src/main/java/org/dimdev/jeid/mixin/modsupport/biometweaker/MixinCommandSetBiome.java
@@ -41,10 +41,12 @@ public class MixinCommandSetBiome {
 
     @Redirect(method = "execute", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/chunk/Chunk;setBiomeArray([B)V"))
     private void reid$setBiomeArray(Chunk instance, byte[] biomeArray,
-                                    @Local BlockPos coord, @Local World world, @Local(ordinal = 4) int x,
-                                    @Local(ordinal = 5) int z, @Share("intBiomeArray") LocalRef<int[]> intBiomeArray) {
+                                    @Local BlockPos coord, @Local World world, @Local(ordinal = 4) int chunkX,
+                                    @Local(ordinal = 5) int chunkZ, @Share("intBiomeArray") LocalRef<int[]> intBiomeArray) {
         // Method calls markDirty()
-        ((INewChunk) world.getChunk(x, z)).setIntBiomeArray(Arrays.copyOf(intBiomeArray.get(), intBiomeArray.get().length));
-        MessageManager.sendClientsBiomeArray(world, new BlockPos(x, coord.getY(), z), Arrays.copyOf(intBiomeArray.get(), intBiomeArray.get().length));
+        int posX = chunkX << 4;
+        int posZ = chunkZ << 4;
+        ((INewChunk) world.getChunk(chunkX, chunkZ)).setIntBiomeArray(Arrays.copyOf(intBiomeArray.get(), intBiomeArray.get().length));
+        MessageManager.sendClientsBiomeArray(world, new BlockPos(posX, coord.getY(), posZ), Arrays.copyOf(intBiomeArray.get(), intBiomeArray.get().length));
     }
 }

--- a/src/main/java/org/dimdev/jeid/network/BiomeArrayMessage.java
+++ b/src/main/java/org/dimdev/jeid/network/BiomeArrayMessage.java
@@ -47,7 +47,7 @@ public class BiomeArrayMessage implements IMessage {
                 WorldClient world = Minecraft.getMinecraft().world;
                 Chunk chunk = world.getChunk(message.chunkX, message.chunkZ);
                 ((INewChunk) chunk).setIntBiomeArray(message.biomeArray);
-                world.markBlockRangeForRenderUpdate(new BlockPos(chunk.getPos().getXStart(), 0, chunk.getPos().getZStart()), new BlockPos(chunk.getPos().getXEnd(), 0, chunk.getPos().getZEnd()));
+                world.markBlockRangeForRenderUpdate(new BlockPos(chunk.getPos().getXStart(), 0, chunk.getPos().getZStart()), new BlockPos(chunk.getPos().getXEnd(), world.getHeight(), chunk.getPos().getZEnd()));
             });
             return null;
         }

--- a/src/main/java/org/dimdev/jeid/network/BiomeChangeMessage.java
+++ b/src/main/java/org/dimdev/jeid/network/BiomeChangeMessage.java
@@ -47,7 +47,7 @@ public class BiomeChangeMessage implements IMessage {
                 WorldClient world = Minecraft.getMinecraft().world;
                 Chunk chunk = world.getChunk(new BlockPos(message.x, 0, message.z));
                 ((INewChunk) chunk).getIntBiomeArray()[(message.z & 15) << 4 | message.x & 15] = message.biomeId;
-                world.markBlockRangeForRenderUpdate(new BlockPos(message.x, 0, message.z), new BlockPos(message.x, 0, message.z));
+                world.markBlockRangeForRenderUpdate(new BlockPos(message.x, 0, message.z), new BlockPos(message.x, world.getHeight(), message.z));
             });
             return null;
         }

--- a/src/main/java/org/dimdev/jeid/network/MessageManager.java
+++ b/src/main/java/org/dimdev/jeid/network/MessageManager.java
@@ -24,7 +24,7 @@ public class MessageManager {
 
     public static void sendClientsBiomeArray(World world, BlockPos pos, int[] biomeArr) {
         MessageManager.CHANNEL.sendToAllTracking(
-                new BiomeArrayMessage(pos.getX(), pos.getZ(), biomeArr),
+                new BiomeArrayMessage(pos.getX() >> 4, pos.getZ() >> 4, biomeArr), // Expects chunkX/Z
                 new NetworkRegistry.TargetPoint(world.provider.getDimension(), pos.getX(), pos.getY(), pos.getZ(), 0.0D) // Range ignored
         );
     }


### PR DESCRIPTION
One more quick PR, biomes changed by mod mechanics should now immediately re-render and be reflected on the client's screen. Also fixes a bug I missed for code using `BiomeArrayMessage` when refactoring the network messages.