### PR TITLE
Fix potion packet being read incorrectly

### DIFF
--- a/src/main/java/org/dimdev/jeid/core/JEIDTransformer.java
+++ b/src/main/java/org/dimdev/jeid/core/JEIDTransformer.java
@@ -16,7 +16,7 @@ import java.util.Iterator;
 import java.util.function.Predicate;
 
 /**
- * Since 2.0.9: Cleaned up obfuscated code; converted most transforms to mixins.
+ * Since 2.1.0: Cleaned up obfuscated code; converted most transforms to mixins.
  * <p>
  * This class was borrowed from Zabi94's MaxPotionIDExtender
  * under MIT License and with full help of Zabi. All credit in this class goes to Zabi

--- a/src/main/java/org/dimdev/jeid/mixin/core/potion/MixinSPacketRemoveEntityEffect.java
+++ b/src/main/java/org/dimdev/jeid/mixin/core/potion/MixinSPacketRemoveEntityEffect.java
@@ -17,6 +17,16 @@ import org.spongepowered.asm.mixin.injection.Redirect;
  */
 @Mixin(value = SPacketRemoveEntityEffect.class)
 public class MixinSPacketRemoveEntityEffect {
+    /**
+     * @reason Disable default id read logic to prevent advancing readerIndex.
+     */
+    @Final
+    @Redirect(method = "readPacketData", at = @At(value = "INVOKE", target = "Lnet/minecraft/network/PacketBuffer;readUnsignedByte()S", ordinal = 0, remap = false))
+    private short reid$defaultReadId(PacketBuffer instance)
+    {
+        return 0;
+    }
+
     @Final
     @ModifyArg(method = "readPacketData", at = @At(value = "INVOKE", target = "Lnet/minecraft/potion/Potion;getPotionById(I)Lnet/minecraft/potion/Potion;"), index = 0)
     private int reid$readIntPotionId(int original, @Local(argsOnly = true) PacketBuffer buf) {

--- a/src/main/java/org/dimdev/jeid/mixin/core/world/MixinAnvilChunkLoader.java
+++ b/src/main/java/org/dimdev/jeid/mixin/core/world/MixinAnvilChunkLoader.java
@@ -23,7 +23,7 @@ public class MixinAnvilChunkLoader {
     /**
      * @reason Read palette from NBT for JustEnoughIDs BlockStateContainers.
      */
-    @Inject(method = "readChunkFromNBT", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/chunk/storage/ExtendedBlockStorage;<init>(IZ)V", shift = At.Shift.BY, by = 2))
+    @Inject(method = "readChunkFromNBT", at = @At(value = "INVOKE", target = "Lnet/minecraft/nbt/NBTTagCompound;getByteArray(Ljava/lang/String;)[B", ordinal = 0))
     private void reid$readPaletteNBT(CallbackInfoReturnable<Chunk> cir, @Local(ordinal = 1) NBTTagCompound storageNBT, @Local ExtendedBlockStorage extendedBlockStorage) {
         int[] palette = storageNBT.hasKey("Palette", 11) ? storageNBT.getIntArray("Palette") : null;
         ((INewBlockStateContainer) extendedBlockStorage.getData()).setTemporaryPalette(palette);

--- a/src/main/java/org/dimdev/jeid/mixin/modsupport/cyclopscore/MixinWorldHelpers.java
+++ b/src/main/java/org/dimdev/jeid/mixin/modsupport/cyclopscore/MixinWorldHelpers.java
@@ -25,7 +25,7 @@ public class MixinWorldHelpers {
     /**
      * @reason Sync clients and don't call unnecessary methods - {@link IChunkProvider#provideChunk} and {@link World#markBlockRangeForRenderUpdate}
      */
-    @Inject(method = "setBiome", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/chunk/Chunk;markDirty()V", shift = At.Shift.AFTER, remap = true), cancellable = true)
+    @Inject(method = "setBiome", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/World;getChunkProvider()Lnet/minecraft/world/chunk/IChunkProvider;", remap = true), cancellable = true)
     private static void reid$sendBiomeMessage(World world, BlockPos pos, Biome biome, CallbackInfo ci) {
         if (!world.isRemote) {
             MessageManager.sendClientsBiomeChange(world, pos, Biome.getIdForBiome(biome));

--- a/src/main/resources/mixins.jeid.abyssalcraft.json
+++ b/src/main/resources/mixins.jeid.abyssalcraft.json
@@ -2,11 +2,7 @@
   "package": "org.dimdev.jeid.mixin.modsupport.abyssalcraft",
   "required": true,
   "refmap": "mixins.jeid.refmap.json",
-  "target": "@env(DEFAULT)",
-  "minVersion": "0.6",
+  "minVersion": "0.8",
   "compatibilityLevel": "JAVA_8",
-  "mixins": ["MixinBiomeUtil"],
-  "injectors": {
-    "maxShiftBy": 10
-  }
+  "mixins": ["MixinBiomeUtil"]
 }

--- a/src/main/resources/mixins.jeid.advancedrocketry.client.json
+++ b/src/main/resources/mixins.jeid.advancedrocketry.client.json
@@ -2,11 +2,7 @@
   "package": "org.dimdev.jeid.mixin.modsupport.advancedrocketry.client",
   "required": true,
   "refmap": "mixins.jeid.refmap.json",
-  "target": "@env(DEFAULT)",
-  "minVersion": "0.6",
+  "minVersion": "0.8",
   "compatibilityLevel": "JAVA_8",
-  "client": ["MixinPacketBiomeIDChange"],
-  "injectors": {
-    "maxShiftBy": 10
-  }
+  "client": ["MixinPacketBiomeIDChange"]
 }

--- a/src/main/resources/mixins.jeid.advancedrocketry.v1_7_0.json
+++ b/src/main/resources/mixins.jeid.advancedrocketry.v1_7_0.json
@@ -2,14 +2,10 @@
   "package": "org.dimdev.jeid.mixin.modsupport.advancedrocketry",
   "required": true,
   "refmap": "mixins.jeid.refmap.json",
-  "target": "@env(DEFAULT)",
-  "minVersion": "0.6",
+  "minVersion": "0.8",
   "compatibilityLevel": "JAVA_8",
   "mixins": [
     "v1_7_0.MixinBiomeHandler",
     "MixinPacketBiomeIDChange"
-  ],
-  "injectors": {
-    "maxShiftBy": 10
-  }
+  ]
 }

--- a/src/main/resources/mixins.jeid.advancedrocketry.v2_0_0.json
+++ b/src/main/resources/mixins.jeid.advancedrocketry.v2_0_0.json
@@ -2,14 +2,10 @@
   "package": "org.dimdev.jeid.mixin.modsupport.advancedrocketry",
   "required": true,
   "refmap": "mixins.jeid.refmap.json",
-  "target": "@env(DEFAULT)",
-  "minVersion": "0.6",
+  "minVersion": "0.8",
   "compatibilityLevel": "JAVA_8",
   "mixins": [
     "v2_0_0.MixinBiomeHandler",
     "MixinPacketBiomeIDChange"
-  ],
-  "injectors": {
-    "maxShiftBy": 10
-  }
+  ]
 }

--- a/src/main/resources/mixins.jeid.atum.json
+++ b/src/main/resources/mixins.jeid.atum.json
@@ -2,13 +2,9 @@
   "package": "org.dimdev.jeid.mixin.modsupport.atum",
   "required": true,
   "refmap": "mixins.jeid.refmap.json",
-  "target": "@env(DEFAULT)",
-  "minVersion": "0.6",
+  "minVersion": "0.8",
   "compatibilityLevel": "JAVA_8",
   "mixins": [
     "MixinGenLayerAtumRiverMix"
-  ],
-  "injectors": {
-    "maxShiftBy": 10
-  }
+  ]
 }

--- a/src/main/resources/mixins.jeid.biomesoplenty.json
+++ b/src/main/resources/mixins.jeid.biomesoplenty.json
@@ -2,14 +2,10 @@
   "package": "org.dimdev.jeid.mixin.modsupport.biomesoplenty",
   "required": true,
   "refmap": "mixins.jeid.refmap.json",
-  "target": "@env(DEFAULT)",
-  "minVersion": "0.6",
+  "minVersion": "0.8",
   "compatibilityLevel": "JAVA_8",
   "mixins": [
     "MixinBOPCommand",
     "MixinModBiomes"
-  ],
-  "injectors": {
-    "maxShiftBy": 10
-  }
+  ]
 }

--- a/src/main/resources/mixins.jeid.biometweaker.json
+++ b/src/main/resources/mixins.jeid.biometweaker.json
@@ -2,15 +2,11 @@
   "package": "org.dimdev.jeid.mixin.modsupport.biometweaker",
   "required": true,
   "refmap": "mixins.jeid.refmap.json",
-  "target": "@env(DEFAULT)",
-  "minVersion": "0.6",
+  "minVersion": "0.8",
   "compatibilityLevel": "JAVA_8",
   "mixins": [
     "MixinBiomeColorMappings",
     "MixinBiomeHelper",
     "MixinCommandSetBiome"
-  ],
-  "injectors": {
-    "maxShiftBy": 10
-  }
+  ]
 }

--- a/src/main/resources/mixins.jeid.bookshelf.json
+++ b/src/main/resources/mixins.jeid.bookshelf.json
@@ -2,13 +2,9 @@
   "package": "org.dimdev.jeid.mixin.modsupport.bookshelf",
   "required": true,
   "refmap": "mixins.jeid.refmap.json",
-  "target": "@env(DEFAULT)",
-  "minVersion": "0.6",
+  "minVersion": "0.8",
   "compatibilityLevel": "JAVA_8",
   "mixins": [
     "MixinWorldUtils"
-  ],
-  "injectors": {
-    "maxShiftBy": 10
-  }
+  ]
 }

--- a/src/main/resources/mixins.jeid.compactmachines.json
+++ b/src/main/resources/mixins.jeid.compactmachines.json
@@ -2,13 +2,9 @@
   "package": "org.dimdev.jeid.mixin.modsupport.compactmachines",
   "required": true,
   "refmap": "mixins.jeid.refmap.json",
-  "target": "@env(DEFAULT)",
-  "minVersion": "0.6",
+  "minVersion": "0.8",
   "compatibilityLevel": "JAVA_8",
   "mixins": [
     "MixinChunkUtils"
-  ],
-  "injectors": {
-    "maxShiftBy": 10
-  }
+  ]
 }

--- a/src/main/resources/mixins.jeid.core.json
+++ b/src/main/resources/mixins.jeid.core.json
@@ -2,7 +2,6 @@
   "package": "org.dimdev.jeid.mixin.core",
   "required": true,
   "refmap": "mixins.jeid.refmap.json",
-  "target": "@env(DEFAULT)",
   "minVersion": "0.8",
   "compatibilityLevel": "JAVA_8",
   "mixins": [
@@ -30,9 +29,5 @@
     "potion.client.MixinNetHandlerPlayClient",
     "world.client.MixinChunk",
     "world.client.MixinWorldSummary"
-  ],
-  "injectors": {
-    "maxShiftBy": 10,
-    "require": 1
-  }
+  ]
 }

--- a/src/main/resources/mixins.jeid.creepingnether.json
+++ b/src/main/resources/mixins.jeid.creepingnether.json
@@ -2,13 +2,9 @@
   "package": "org.dimdev.jeid.mixin.modsupport.creepingnether",
   "required": true,
   "refmap": "mixins.jeid.refmap.json",
-  "target": "@env(DEFAULT)",
-  "minVersion": "0.6",
+  "minVersion": "0.8",
   "compatibilityLevel": "JAVA_8",
   "mixins": [
     "MixinCorruptorAbstract"
-  ],
-  "injectors": {
-    "maxShiftBy": 10
-  }
+  ]
 }

--- a/src/main/resources/mixins.jeid.cubicchunks.json
+++ b/src/main/resources/mixins.jeid.cubicchunks.json
@@ -2,8 +2,7 @@
   "package": "org.dimdev.jeid.mixin.modsupport.cubicchunks",
   "required": true,
   "refmap": "mixins.jeid.refmap.json",
-  "target": "@env(DEFAULT)",
-  "minVersion": "0.6",
+  "minVersion": "0.8",
   "compatibilityLevel": "JAVA_8",
   "mixins": [
     "MixinCube",
@@ -12,8 +11,5 @@
     "MixinIONbtWriter",
     "MixinVanillaCompatibilityGenerator",
     "MixinWorldEncoder"
-  ],
-  "injectors": {
-    "maxShiftBy": 10
-  }
+  ]
 }

--- a/src/main/resources/mixins.jeid.cyclopscore.json
+++ b/src/main/resources/mixins.jeid.cyclopscore.json
@@ -2,13 +2,9 @@
   "package": "org.dimdev.jeid.mixin.modsupport.cyclopscore",
   "required": true,
   "refmap": "mixins.jeid.refmap.json",
-  "target": "@env(DEFAULT)",
-  "minVersion": "0.6",
+  "minVersion": "0.8",
   "compatibilityLevel": "JAVA_8",
   "mixins": [
     "MixinWorldHelpers"
-  ],
-  "injectors": {
-    "maxShiftBy": 10
-  }
+  ]
 }

--- a/src/main/resources/mixins.jeid.extrautils2.json
+++ b/src/main/resources/mixins.jeid.extrautils2.json
@@ -2,14 +2,10 @@
   "package": "org.dimdev.jeid.mixin.modsupport.extrautils2",
   "required": true,
   "refmap": "mixins.jeid.refmap.json",
-  "target": "@env(DEFAULT)",
-  "minVersion": "0.6",
+  "minVersion": "0.8",
   "compatibilityLevel": "JAVA_8",
   "mixins": [
     "MixinBiomeManip",
     "MixinWorldProviderSpecialDim"
-  ],
-  "injectors": {
-    "maxShiftBy": 10
-  }
+  ]
 }

--- a/src/main/resources/mixins.jeid.gaiadimension.json
+++ b/src/main/resources/mixins.jeid.gaiadimension.json
@@ -1,14 +1,8 @@
 {
   "package": "org.dimdev.jeid.mixin.modsupport.gaiadimension",
-  "required": true,
-  "refmap": "mixins.jeid.refmap.json",
-  "target": "@env(DEFAULT)",
-  "minVersion": "0.6",
+  "minVersion": "0.8",
   "compatibilityLevel": "JAVA_8",
   "mixins": [
     "MixinGenLayerGDRiverMix"
-  ],
-  "injectors": {
-    "maxShiftBy": 10
-  }
+  ]
 }

--- a/src/main/resources/mixins.jeid.geographicraft.json
+++ b/src/main/resources/mixins.jeid.geographicraft.json
@@ -2,13 +2,9 @@
   "package": "org.dimdev.jeid.mixin.modsupport.geographicraft",
   "required": true,
   "refmap": "mixins.jeid.refmap.json",
-  "target": "@env(DEFAULT)",
-  "minVersion": "0.6",
+  "minVersion": "0.8",
   "compatibilityLevel": "JAVA_8",
   "mixins": [
     "MixinDimensionManager"
-  ],
-  "injectors": {
-    "maxShiftBy": 10
-  }
+  ]
 }

--- a/src/main/resources/mixins.jeid.hammercore.json
+++ b/src/main/resources/mixins.jeid.hammercore.json
@@ -2,13 +2,9 @@
   "package": "org.dimdev.jeid.mixin.modsupport.hammercore",
   "required": true,
   "refmap": "mixins.jeid.refmap.json",
-  "target": "@env(DEFAULT)",
-  "minVersion": "0.6",
+  "minVersion": "0.8",
   "compatibilityLevel": "JAVA_8",
   "mixins": [
     "MixinWorldLocation"
-  ],
-  "injectors": {
-    "maxShiftBy": 10
-  }
+  ]
 }

--- a/src/main/resources/mixins.jeid.journeymap.json
+++ b/src/main/resources/mixins.jeid.journeymap.json
@@ -2,13 +2,9 @@
   "package": "org.dimdev.jeid.mixin.modsupport.journeymap",
   "required": true,
   "refmap": "mixins.jeid.refmap.json",
-  "target": "@env(DEFAULT)",
-  "minVersion": "0.6",
+  "minVersion": "0.8",
   "compatibilityLevel": "JAVA_8",
   "mixins": [
     "MixinChunkMD"
-  ],
-  "injectors": {
-    "maxShiftBy": 10
-  }
+  ]
 }

--- a/src/main/resources/mixins.jeid.moreplanets.json
+++ b/src/main/resources/mixins.jeid.moreplanets.json
@@ -2,13 +2,9 @@
   "package": "org.dimdev.jeid.mixin.modsupport.moreplanets",
   "required": true,
   "refmap": "mixins.jeid.refmap.json",
-  "target": "@env(DEFAULT)",
-  "minVersion": "0.6",
+  "minVersion": "0.8",
   "compatibilityLevel": "JAVA_8",
   "mixins": [
     "MixinGenLayerRiversMix"
-  ],
-  "injectors": {
-    "maxShiftBy": 10
-  }
+  ]
 }

--- a/src/main/resources/mixins.jeid.mystcraft.json
+++ b/src/main/resources/mixins.jeid.mystcraft.json
@@ -2,13 +2,9 @@
   "package": "org.dimdev.jeid.mixin.modsupport.mystcraft",
   "required": true,
   "refmap": "mixins.jeid.refmap.json",
-  "target": "@env(DEFAULT)",
-  "minVersion": "0.6",
+  "minVersion": "0.8",
   "compatibilityLevel": "JAVA_8",
   "mixins": [
     "MixinBiomeReplacer"
-  ],
-  "injectors": {
-    "maxShiftBy": 10
-  }
+  ]
 }

--- a/src/main/resources/mixins.jeid.thaumcraft.json
+++ b/src/main/resources/mixins.jeid.thaumcraft.json
@@ -2,13 +2,9 @@
   "package": "org.dimdev.jeid.mixin.modsupport.thaumcraft",
   "required": true,
   "refmap": "mixins.jeid.refmap.json",
-  "target": "@env(DEFAULT)",
-  "minVersion": "0.6",
+  "minVersion": "0.8",
   "compatibilityLevel": "JAVA_8",
   "mixins": [
     "MixinUtils"
-  ],
-  "injectors": {
-    "maxShiftBy": 10
-  }
+  ]
 }

--- a/src/main/resources/mixins.jeid.thebetweenlands.json
+++ b/src/main/resources/mixins.jeid.thebetweenlands.json
@@ -2,14 +2,10 @@
   "package": "org.dimdev.jeid.mixin.modsupport.thebetweenlands",
   "required": true,
   "refmap": "mixins.jeid.refmap.json",
-  "target": "@env(DEFAULT)",
-  "minVersion": "0.6",
+  "minVersion": "0.8",
   "compatibilityLevel": "JAVA_8",
   "mixins": [
     "MixinBlockSpreadingDeath",
     "MixinGenLayerVoronoiZoomInstanced"
-  ],
-  "injectors": {
-    "maxShiftBy": 10
-  }
+  ]
 }

--- a/src/main/resources/mixins.jeid.tofucraft.json
+++ b/src/main/resources/mixins.jeid.tofucraft.json
@@ -2,14 +2,10 @@
   "package": "org.dimdev.jeid.mixin.modsupport.tofucraft",
   "required": true,
   "refmap": "mixins.jeid.refmap.json",
-  "target": "@env(DEFAULT)",
-  "minVersion": "0.6",
+  "minVersion": "0.8",
   "compatibilityLevel": "JAVA_8",
   "mixins": [
     "MixinGenLayerRiverMix",
     "MixinGenLayerTofuVoronoiZoom"
-  ],
-  "injectors": {
-    "maxShiftBy": 10
-  }
+  ]
 }

--- a/src/main/resources/mixins.jeid.tropicraft.json
+++ b/src/main/resources/mixins.jeid.tropicraft.json
@@ -2,13 +2,9 @@
   "package": "org.dimdev.jeid.mixin.modsupport.tropicraft",
   "required": true,
   "refmap": "mixins.jeid.refmap.json",
-  "target": "@env(DEFAULT)",
-  "minVersion": "0.6",
+  "minVersion": "0.8",
   "compatibilityLevel": "JAVA_8",
   "mixins": [
     "MixinGenLayerTropiVoronoiZoom"
-  ],
-  "injectors": {
-    "maxShiftBy": 10
-  }
+  ]
 }

--- a/src/main/resources/mixins.jeid.twilightforest.json
+++ b/src/main/resources/mixins.jeid.twilightforest.json
@@ -2,14 +2,10 @@
   "package": "org.dimdev.jeid.mixin.modsupport.twilightforest",
   "required": true,
   "refmap": "mixins.jeid.refmap.json",
-  "target": "@env(DEFAULT)",
-  "minVersion": "0.6",
+  "minVersion": "0.8",
   "compatibilityLevel": "JAVA_8",
   "mixins": [
     "MixinBlockTFMagicLogSpecial",
     "MixinGenLayerTFRiverMix"
-  ],
-  "injectors": {
-    "maxShiftBy": 10
-  }
+  ]
 }

--- a/src/main/resources/mixins.jeid.worldedit.json
+++ b/src/main/resources/mixins.jeid.worldedit.json
@@ -2,13 +2,9 @@
   "package": "org.dimdev.jeid.mixin.modsupport.worldedit",
   "required": true,
   "refmap": "mixins.jeid.refmap.json",
-  "target": "@env(DEFAULT)",
-  "minVersion": "0.6",
+  "minVersion": "0.8",
   "compatibilityLevel": "JAVA_8",
   "mixins": [
     "MixinBaseBlock"
-  ],
-  "injectors": {
-    "maxShiftBy": 10
-  }
+  ]
 }


### PR DESCRIPTION
Fixes `SPacketRemoveEntity` mixin causing client-side network issues because the default `readUnsignedByte()` for the potion id was still being called and advancing the `readerIndex` more than allowed. Was a bug from refactoring the transformer method to this mixin in 2.1.0. Fixes #49 
Also some minor cleanup.