### PR TITLE
Remove deprecated transformer code

### DIFF
--- a/src/main/java/org/dimdev/jeid/JEID.java
+++ b/src/main/java/org/dimdev/jeid/JEID.java
@@ -45,7 +45,6 @@ public class JEID {
         + "after:twilightforest;"
         + "after:wyrmsofnyrus;"
         + "after:worldedit";
-    public static final Logger LOGGER = LogManager.getLogger(JEID.NAME);
 
     @Mod.EventHandler
     public void onPreInit(FMLPreInitializationEvent event) {

--- a/src/main/java/org/dimdev/jeid/JEIDLogger.java
+++ b/src/main/java/org/dimdev/jeid/JEIDLogger.java
@@ -1,0 +1,10 @@
+package org.dimdev.jeid;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import org.dimdev.jeid.jeid.Tags;
+
+public class JEIDLogger {
+    public static final Logger LOGGER = LogManager.getLogger(Tags.MOD_NAME);
+}

--- a/src/main/java/org/dimdev/jeid/core/JEIDTransformer.java
+++ b/src/main/java/org/dimdev/jeid/core/JEIDTransformer.java
@@ -1,15 +1,10 @@
 package org.dimdev.jeid.core;
 
 import net.minecraft.launchwrapper.IClassTransformer;
-import net.minecraft.potion.Potion;
-import net.minecraft.potion.PotionEffect;
-import net.minecraft.util.ResourceLocation;
-import net.minecraft.util.registry.RegistryNamespaced;
 import net.minecraftforge.fml.relauncher.FMLLaunchHandler;
 import org.objectweb.asm.ClassReader;
 import org.objectweb.asm.ClassWriter;
 import org.objectweb.asm.Opcodes;
-import org.objectweb.asm.Type;
 import org.objectweb.asm.tree.*;
 
 import java.util.Iterator;
@@ -25,9 +20,6 @@ import java.util.function.Predicate;
  * <a href="https://github.com/zabi94/MaxPotionIDExtender">MaxPotionIDExtender by Zabi94</a>
  */
 public class JEIDTransformer implements IClassTransformer {
-    @Deprecated
-    public static RegistryNamespaced<ResourceLocation, Potion> REGISTRY;
-
     @Override
     public byte[] transform(String name, String transformedName, byte[] basicClass) {
         if (transformedName.equals("net.minecraft.item.ItemStack")) {
@@ -107,106 +99,6 @@ public class JEIDTransformer implements IClassTransformer {
         return cw.toByteArray();
     }
 
-    /**
-     * This is no longer used as it has been converted into a mixin.
-     * @see org.dimdev.jeid.mixin.core.potion.MixinSPacketRemoveEntityEffect
-     */
-    @Deprecated
-    private byte[] transformSPacketRemoveEntityEffect(byte[] basicClass) {
-        ClassReader cr = new ClassReader(basicClass);
-        ClassNode cn = new ClassNode();
-        cr.accept(cn, 0);
-
-        // Redirect readUnsignedByte (aka short) to readInt
-        String packetBuffer = "net/minecraft/network/PacketBuffer";
-        String descPacketData = "(L" + packetBuffer + ";)V";
-        MethodNode rpd = locateMethod(cn, descPacketData, "readPacketData", "func_148837_a");
-        AbstractInsnNode target = locateTargetInsn(rpd, n -> n.getOpcode() == Opcodes.INVOKEVIRTUAL && ((MethodInsnNode) n).name.equals("readUnsignedByte"));
-        rpd.instructions.insert(target, new MethodInsnNode(Opcodes.INVOKEVIRTUAL, packetBuffer, "readInt", "()I", false));
-        rpd.instructions.remove(target);
-
-        // Redirect writeByte to writeInt
-        MethodNode wpd = locateMethod(cn, descPacketData, "writePacketData", "func_148840_b");
-        target = locateTargetInsn(wpd, n -> n.getOpcode() == Opcodes.INVOKEVIRTUAL && ((MethodInsnNode) n).name.equals("writeByte"));
-        wpd.instructions.insert(target, new MethodInsnNode(Opcodes.INVOKEVIRTUAL, packetBuffer, "writeInt", "(I)Lio/netty/buffer/ByteBuf;", false));
-        wpd.instructions.remove(target);
-
-        ClassWriter cw = new ClassWriter(0);
-        cn.accept(cw);
-        return cw.toByteArray();
-    }
-
-    /**
-     * This is no longer used as it has been converted into a mixin.
-     * @see org.dimdev.jeid.mixin.core.potion.MixinSPacketEntityEffect
-     */
-    @Deprecated
-    private byte[] transformSPacketEntityEffect(byte[] basicClass) {
-        ClassReader cr = new ClassReader(basicClass);
-        ClassNode cn = new ClassNode();
-        cr.accept(cn, 0);
-
-        String potionEffect = "net/minecraft/potion/PotionEffect";
-        String sPacketEntityEffect = "net/minecraft/network/play/server/SPacketEntityEffect";
-        String packetBuffer = "net/minecraft/network/PacketBuffer";
-        String descPacketData = "(L" + packetBuffer + ";)V";
-        // Add new field, int effectInt
-        cn.fields.add(new FieldNode(Opcodes.ACC_PUBLIC, "effectInt", "I", null, 0));
-
-        MethodNode mnInit = locateMethod(cn, "(IL" + potionEffect + ";)V", "<init>");
-        Iterator<AbstractInsnNode> i = mnInit.instructions.iterator();
-        AbstractInsnNode targetNode = null;
-        int line = 0;
-        while (i.hasNext() && targetNode == null) {
-            AbstractInsnNode node = i.next();
-            if (node instanceof LineNumberNode) {
-                if (line == 1) {
-                    targetNode = node;
-                }
-                line++;
-            }
-        }
-
-        if (targetNode == null) {
-            throw new RuntimeException("Can't find target node for SPacketEntityEffect constructor");
-        }
-
-        // Initialize effectInt in constructors
-        // These are reversed, they get pushed down the stack
-        mnInit.instructions.insert(targetNode, new FieldInsnNode(Opcodes.PUTFIELD, sPacketEntityEffect, "effectInt", "I"));
-        mnInit.instructions.insert(targetNode, new MethodInsnNode(Opcodes.INVOKESTATIC, Type.getInternalName(this.getClass()), "getIdFromPotEffect", "(L" + potionEffect + ";)I", false));
-        mnInit.instructions.insert(targetNode, new VarInsnNode(Opcodes.ALOAD, 2));
-        mnInit.instructions.insert(targetNode, new VarInsnNode(Opcodes.ALOAD, 0));
-
-        MethodNode mnEmptyInit = locateMethod(cn, "()V", "<init>");
-        AbstractInsnNode tgt = locateTargetInsn(mnEmptyInit, n -> n.getOpcode() == Opcodes.RETURN);
-        mnEmptyInit.instructions.insertBefore(tgt, new VarInsnNode(Opcodes.ALOAD, 0));
-        mnEmptyInit.instructions.insertBefore(tgt, new LdcInsnNode(0));
-        mnEmptyInit.instructions.insertBefore(tgt, new FieldInsnNode(Opcodes.PUTFIELD, sPacketEntityEffect, "effectInt", "I"));
-
-        // Patch readPacketData: this.effectInt = buf.readVarInt();
-        MethodNode mnReadPacket = locateMethod(cn, descPacketData, "readPacketData", "func_148837_a");
-        AbstractInsnNode target = locateTargetInsn(mnReadPacket, n -> n.getOpcode() == Opcodes.RETURN).getPrevious().getPrevious();
-        mnReadPacket.instructions.insertBefore(target, new VarInsnNode(Opcodes.ALOAD, 0));
-        mnReadPacket.instructions.insertBefore(target, new VarInsnNode(Opcodes.ALOAD, 1));
-        mnReadPacket.instructions.insertBefore(target, new MethodInsnNode(Opcodes.INVOKEVIRTUAL, packetBuffer, (JEIDLoadingPlugin.isDeobf ? "readVarInt" : "func_150792_a"), "()I", false));
-        mnReadPacket.instructions.insertBefore(target, new FieldInsnNode(Opcodes.PUTFIELD, sPacketEntityEffect, "effectInt", "I"));
-
-        // Patch writePacketData: buf.writeVarInt(effectInt);
-        MethodNode mnWritePacket = locateMethod(cn, descPacketData, "writePacketData", "func_148840_b");
-        AbstractInsnNode wpTarget = locateTargetInsn(mnWritePacket, n -> n.getOpcode() == Opcodes.RETURN).getPrevious().getPrevious();
-        mnWritePacket.instructions.insertBefore(wpTarget, new VarInsnNode(Opcodes.ALOAD, 1));
-        mnWritePacket.instructions.insertBefore(wpTarget, new VarInsnNode(Opcodes.ALOAD, 0));
-        mnWritePacket.instructions.insertBefore(wpTarget, new FieldInsnNode(Opcodes.GETFIELD, sPacketEntityEffect, "effectInt", "I"));
-        mnWritePacket.instructions.insertBefore(wpTarget, new MethodInsnNode(Opcodes.INVOKEVIRTUAL, packetBuffer, (JEIDLoadingPlugin.isDeobf ? "writeVarInt" : "func_150787_b"), "(I)L" + packetBuffer + ";", false));
-        mnWritePacket.instructions.insertBefore(wpTarget, new InsnNode(Opcodes.POP));
-
-        // Max stack size has been modified
-        ClassWriter cw = new ClassWriter(ClassWriter.COMPUTE_MAXS);
-        cn.accept(cw);
-        return cw.toByteArray();
-    }
-
     private byte[] transformPotionEffect(byte[] basicClass) {
         ClassReader cr = new ClassReader(basicClass);
         ClassNode cn = new ClassNode();
@@ -235,40 +127,6 @@ public class JEIDTransformer implements IClassTransformer {
         ClassWriter cw = new ClassWriter(ClassWriter.COMPUTE_MAXS);
         cn.accept(cw);
         return cw.toByteArray();
-    }
-
-    /**
-     * This is no longer used as it has been converted into a mixin.
-     * @see org.dimdev.jeid.mixin.core.potion.client.MixinNetHandlerPlayClient
-     */
-    @Deprecated
-    private byte[] transformNetHandlerPlayClient(byte[] basicClass) {
-        ClassReader cr = new ClassReader(basicClass);
-        ClassNode cn = new ClassNode();
-        cr.accept(cn, 0);
-
-        String sPacketEntityEffect = "net/minecraft/network/play/server/SPacketEntityEffect";
-        MethodNode mn = locateMethod(cn, "(L" + sPacketEntityEffect + ";)V", "handleEntityEffect", "func_147260_a");
-        AbstractInsnNode target = locateTargetInsn(mn, n -> n.getOpcode() == Opcodes.SIPUSH);
-        mn.instructions.remove(target.getPrevious());
-        mn.instructions.remove(target.getNext());
-        // Redirect getEffectID to effectInt
-        mn.instructions.insertBefore(target, new FieldInsnNode(Opcodes.GETFIELD, sPacketEntityEffect, "effectInt", "I"));
-        // Remove bitwise operation
-        mn.instructions.remove(target);
-
-        ClassWriter cw = new ClassWriter(ClassWriter.COMPUTE_MAXS);
-        cn.accept(cw);
-        return cw.toByteArray();
-    }
-
-    /**
-     * No longer used.
-     * @see JEIDTransformer#transformSPacketRemoveEntityEffect(byte[])
-     */
-    @Deprecated
-    public static int getIdFromPotEffect(PotionEffect pe) {
-        return REGISTRY.getIDForObject(pe.getPotion());
     }
 }
 

--- a/src/main/java/org/dimdev/jeid/mixin/modsupport/biometweaker/MixinCommandSetBiome.java
+++ b/src/main/java/org/dimdev/jeid/mixin/modsupport/biometweaker/MixinCommandSetBiome.java
@@ -9,7 +9,7 @@ import net.minecraft.server.MinecraftServer;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 import net.minecraft.world.chunk.Chunk;
-import org.dimdev.jeid.JEID;
+import org.dimdev.jeid.JEIDLogger;
 import org.dimdev.jeid.ducks.INewChunk;
 import org.dimdev.jeid.network.MessageManager;
 import org.spongepowered.asm.mixin.Mixin;
@@ -27,7 +27,7 @@ public class MixinCommandSetBiome {
     private void reid$setBiomeArrayElement(MinecraftServer server, ICommandSender sender, String[] args, CallbackInfo ci,
                                            @Local BlockPos coord, @Local World world, @Local(ordinal = 0) int id,
                                            @Local(ordinal = 2) int x, @Local(ordinal = 3) int z, @Local Chunk chunk) {
-        JEID.LOGGER.info("setting biome at {}, {}", x, z);
+        JEIDLogger.LOGGER.info("setting biome at {}, {}", x, z);
         // Method calls markDirty()
         ((INewChunk) chunk).getIntBiomeArray()[(z & 0xF) << 4 | x & 0xF] = id;
     }


### PR DESCRIPTION
The mod refactor seems to have gone well, so it should be safe to remove the old transformer code that I marked as deprecated in 2.1.0. It seems to be best practice to avoid referencing any MC classes to avoid unnecessary classloading (which may interfere with other transformers depending on load order), so removed the no longer used code.

Also moves the logger back to its own class like before, just to be safe with classloading.