### PR TITLE
Add support for Advanced Rocketry - Reworked (AR fork)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -139,10 +139,12 @@ dependencies {
     compileOnly rfg.deobf("curse.maven:geographicraft-76544:2497541")
     compileOnly rfg.deobf("curse.maven:mystcraft-224599:2958490")
     compileOnly rfg.deobf("curse.maven:hammercore-247401:3366814")
-    // Advanced Rocketry 1.7.0
+    // Advanced Rocketry 1.7.0 <- Build with this version
     compileOnly rfg.deobf("curse.maven:advancedrocketry-236542:3015079")
     // Advanced Rocketry 2.0.0
     // compileOnly rfg.deobf("curse.maven:advancedrocketry-236542:4671856")
+    // Advanced Rocketry - Reworked (Fork by OberToffel)
+    // compileOnly rfg.deobf('curse.maven:advancedrocketry-reworked-1024225:5486514')
     compileOnly rfg.deobf("curse.maven:libvulpes-236541:3434864")
     compileOnly rfg.deobf("curse.maven:worldedit-225608:2941712")
     compileOnly rfg.deobf("curse.maven:journeymap-32274:2916002")

--- a/src/main/java/org/dimdev/jeid/mixin/modsupport/advancedrocketry/MixinBiomeHandler.java
+++ b/src/main/java/org/dimdev/jeid/mixin/modsupport/advancedrocketry/MixinBiomeHandler.java
@@ -44,4 +44,13 @@ public class MixinBiomeHandler {
         chunk.markDirty();
         // Method sends packet
     }
+
+    @Dynamic("Use int biome array for AR-Reworked (Fork by OberToffel)")
+    @Group(name = "versionAgnosticAR", min = 1, max = 2)
+    @Inject(method = "changeBiome(Lnet/minecraft/world/World;Lnet/minecraft/world/biome/Biome;Lnet/minecraft/util/math/BlockPos;Z)V", at = @At(value = "INVOKE", target = "sendToNearby(Lzmaster587/libVulpes/network/BasePacket;ILnet/minecraft/util/math/BlockPos;D)V", ordinal = 0), locals = LocalCapture.CAPTURE_FAILHARD, require = 0)
+    private static void reid$toIntBiomeArrayFork(World world, Biome biomeId, BlockPos pos, boolean regen_vegetation, CallbackInfo ci, Chunk chunk) {
+        ((INewChunk) chunk).getIntBiomeArray()[(pos.getZ() & 0xF) << 4 | pos.getX() & 0xF] = Biome.getIdForBiome(biomeId);
+        chunk.markDirty();
+        // Method sends packet
+    }
 }


### PR DESCRIPTION
A currently maintained [fork](https://www.curseforge.com/minecraft/mc-mods/advanced-rocketry-2) of Advanced Rocketry (AR) changes the signature of the method I target in the AR mixin. Adds the new signature as another `@Dynamic` injection target, which fixes mixin failure crashes if using this fork and the biome change remote.