### PR TITLE
Improve performance of chunk saving 

### DIFF
--- a/src/main/java/org/dimdev/jeid/mixin/core/world/MixinStateImplementation.java
+++ b/src/main/java/org/dimdev/jeid/mixin/core/world/MixinStateImplementation.java
@@ -1,19 +1,31 @@
 package org.dimdev.jeid.mixin.core.world;
 
-import com.google.common.collect.*;
-import java.util.*;
-import net.minecraft.block.properties.*;
-import net.minecraft.block.state.BlockStateContainer.*;
-import org.spongepowered.asm.mixin.*;
-import org.spongepowered.asm.mixin.injection.*;
-import org.spongepowered.asm.mixin.injection.callback.*;
+import com.google.common.collect.ImmutableMap;
+import java.util.Objects;
+import net.minecraft.block.Block;
+import net.minecraft.block.properties.IProperty;
+import net.minecraft.block.state.BlockStateContainer.StateImplementation;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Overwrite;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(StateImplementation.class)
 public class MixinStateImplementation {
 
+    @Unique
     private int hashCodeValue;
 
     @Shadow
+    @Final
+    private Block block;
+
+    @Shadow
+    @Final
     private ImmutableMap<IProperty<?>, Comparable<?>> properties;
 
     @Inject(
@@ -21,7 +33,7 @@ public class MixinStateImplementation {
         at = @At("RETURN")
     )
     private void initHashCode(CallbackInfo ci) {
-        hashCodeValue = Objects.hash(this, properties);
+        hashCodeValue = Objects.hash(block, properties);
     }
 
     /**

--- a/src/main/java/org/dimdev/jeid/mixin/core/world/MixinStateImplementation.java
+++ b/src/main/java/org/dimdev/jeid/mixin/core/world/MixinStateImplementation.java
@@ -1,6 +1,7 @@
 package org.dimdev.jeid.mixin.core.world;
 
 import com.google.common.collect.*;
+import java.util.*;
 import net.minecraft.block.properties.*;
 import net.minecraft.block.state.BlockStateContainer.*;
 import org.spongepowered.asm.mixin.*;
@@ -20,7 +21,7 @@ public class MixinStateImplementation {
         at = @At("RETURN")
     )
     private void initHashCode(CallbackInfo ci) {
-        hashCodeValue = properties.hashCode();
+        hashCodeValue = Objects.hash(this, properties);
     }
 
     /**
@@ -28,7 +29,7 @@ public class MixinStateImplementation {
      * @reason it should just return value. kinda have no sense to @Inject
      */
     @Overwrite
-    public int hashCode(){
+    public int hashCode() {
         return hashCodeValue;
     }
 

--- a/src/main/java/org/dimdev/jeid/mixin/core/world/MixinStateImplementation.java
+++ b/src/main/java/org/dimdev/jeid/mixin/core/world/MixinStateImplementation.java
@@ -1,0 +1,35 @@
+package org.dimdev.jeid.mixin.core.world;
+
+import com.google.common.collect.*;
+import net.minecraft.block.properties.*;
+import net.minecraft.block.state.BlockStateContainer.*;
+import org.spongepowered.asm.mixin.*;
+import org.spongepowered.asm.mixin.injection.*;
+import org.spongepowered.asm.mixin.injection.callback.*;
+
+@Mixin(StateImplementation.class)
+public class MixinStateImplementation {
+
+    private int hashCodeValue;
+
+    @Shadow
+    private ImmutableMap<IProperty<?>, Comparable<?>> properties;
+
+    @Inject(
+        method = "<init>",
+        at = @At("RETURN")
+    )
+    private void initHashCode(CallbackInfo ci) {
+        hashCodeValue = properties.hashCode();
+    }
+
+    /**
+     * @author hohserg
+     * @reason it should just return value. kinda have no sense to @Inject
+     */
+    @Overwrite
+    public int hashCode(){
+        return hashCodeValue;
+    }
+
+}

--- a/src/main/resources/mixins.jeid.core.json
+++ b/src/main/resources/mixins.jeid.core.json
@@ -21,6 +21,7 @@
     "world.MixinChunkPrimer",
     "world.MixinChunkProviderServer",
     "world.MixinGenLayerVoronoiZoom",
+    "world.MixinStateImplementation",
     "world.MixinWorldInfo"
   ],
   "client": [


### PR DESCRIPTION
We have some frequently used logic at https://github.com/TerraFirmaCraft-The-Final-Frontier/RoughlyEnoughIDs/blob/master/src/main/java/org/dimdev/jeid/mixin/core/world/MixinBlockStateContainer.java#L60-L64
that uses IBlockState as a key of HashMap, so this pr about caching of IBlockState#hashCode to not compute a same value multiple times.
Also, the second commit aims to fix hashCode collisions by considering a block instance instead of only properties for hashCode of IBlockState