### PR TITLE
Add biome support for Chunk Pregenerator's chunk viewer

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -169,7 +169,10 @@ dependencies {
     compileOnly rfg.deobf("curse.maven:cubicchunks-292243:5135427")
     // RTG+ should also work
     compileOnly rfg.deobf("curse.maven:rtg-unofficial-648514:4696300")
+    implementation rfg.deobf("curse.maven:chunk-pregenerator-267193:5632153")
 
+    // Chunk Pregenerator dependency
+    runtimeOnly "curse.maven:carbon-config-898104:5504476"
     // implementation "curse.maven:LibVulpes-236541:3801015"
     // implementation "curse.maven:Baubles-227083:2518667"
     // implementation "curse.maven:mm-library-368098:3254750"

--- a/build.gradle
+++ b/build.gradle
@@ -169,10 +169,10 @@ dependencies {
     compileOnly rfg.deobf("curse.maven:cubicchunks-292243:5135427")
     // RTG+ should also work
     compileOnly rfg.deobf("curse.maven:rtg-unofficial-648514:4696300")
-    implementation rfg.deobf("curse.maven:chunk-pregenerator-267193:5632153")
+    compileOnly rfg.deobf("curse.maven:chunk-pregenerator-267193:5632153")
 
     // Chunk Pregenerator dependency
-    runtimeOnly "curse.maven:carbon-config-898104:5504476"
+    // runtimeOnly "curse.maven:carbon-config-898104:5504476"
     // implementation "curse.maven:LibVulpes-236541:3801015"
     // implementation "curse.maven:Baubles-227083:2518667"
     // implementation "curse.maven:mm-library-368098:3254750"

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,7 +5,7 @@ org.gradle.jvmargs = -Xmx3G
 # Mod Information
 maven_group = org.dimdev.jeid
 mod_name = JustEnoughIDs
-mod_version = 2.2.1
+mod_version = 2.2.2
 archives_base_name = jeid
 
 # If any properties changes below this line, run `gradlew setupDecompWorkspace` and refresh gradle again to ensure everything is working correctly.

--- a/src/main/java/org/dimdev/jeid/core/JEIDMixinLoader.java
+++ b/src/main/java/org/dimdev/jeid/core/JEIDMixinLoader.java
@@ -43,6 +43,9 @@ public class JEIDMixinLoader implements ILateMixinLoader {
         if (Loader.isModLoaded("creepingnether")) {
             configs.add("mixins.jeid.creepingnether.json");
         }
+        if (Loader.isModLoaded("chunkpregenerator")) {
+            configs.add("mixins.jeid.chunkpregenerator.json");
+        }
         if (Loader.isModLoaded("cubicchunks")) {
             configs.add("mixins.jeid.cubicchunks.json");
         }

--- a/src/main/java/org/dimdev/jeid/mixin/modsupport/chunkpregenerator/MixinBiomeEntry.java
+++ b/src/main/java/org/dimdev/jeid/mixin/modsupport/chunkpregenerator/MixinBiomeEntry.java
@@ -1,0 +1,30 @@
+package org.dimdev.jeid.mixin.modsupport.chunkpregenerator;
+
+import net.minecraft.world.biome.Biome;
+import net.minecraft.world.chunk.Chunk;
+
+import com.llamalad7.mixinextras.sugar.Local;
+import org.dimdev.jeid.ducks.INewChunk;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+import pregenerator.impl.tracking.types.BaseWorldEntry;
+import pregenerator.impl.tracking.types.BiomeEntry;
+
+@Mixin(value = BiomeEntry.class, remap = false)
+public class MixinBiomeEntry {
+    @Unique
+    private static final byte[] SKIP_BIOME_ARRAY = new byte[0];
+
+    @Redirect(method = "getChunk", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/chunk/Chunk;getBiomeArray()[B", remap = true))
+    private static byte[] reid$countIntBiomes(Chunk instance, @Local BaseWorldEntry.Counter<Biome> counter) {
+        final int[] biomeArray = ((INewChunk) instance).getIntBiomeArray();
+        for (int id : biomeArray) {
+            Biome biome = Biome.getBiome(id);
+            if (biome != null) counter.add(biome);
+        }
+        // empty byte[], skips original biome counting
+        return SKIP_BIOME_ARRAY;
+    }
+}

--- a/src/main/resources/mixins.jeid.chunkpregenerator.json
+++ b/src/main/resources/mixins.jeid.chunkpregenerator.json
@@ -1,0 +1,10 @@
+{
+  "package": "org.dimdev.jeid.mixin.modsupport.chunkpregenerator",
+  "required": true,
+  "refmap": "mixins.jeid.refmap.json",
+  "minVersion": "0.8",
+  "compatibilityLevel": "JAVA_8",
+  "mixins": [
+    "MixinBiomeEntry"
+  ]
+}


### PR DESCRIPTION
Adds support for biome ids in Chunk Pregenerator's tracker UI for chunks. Now the tracker can accurately show the counts of biomes in each chunk. Previously was not supported and the tracker only counted the default error biome.

Bumps version to 2.2.2.