### PR TITLE
Add support for WarpDrive

### DIFF
--- a/gradle/scripts/dependencies.gradle
+++ b/gradle/scripts/dependencies.gradle
@@ -100,6 +100,7 @@ dependencies {
     compileOnly rfg.deobf("curse.maven:naturescompass-252848:2893527")
     compileOnly rfg.deobf("curse.maven:biomestaff-299907:2597577")
     compileOnly rfg.deobf("curse.maven:kathairis-291129:2710928")
+    compileOnly rfg.deobf("curse.maven:warpdrive-233565:3762066")
 
     compileOnly rfg.deobf("curse.maven:cubicchunks-292243:5135427")
     // RTG+ should also work

--- a/src/main/java/org/dimdev/jeid/mixin/modsupport/kathairis/MixinChunkGeneratorMystic.java
+++ b/src/main/java/org/dimdev/jeid/mixin/modsupport/kathairis/MixinChunkGeneratorMystic.java
@@ -14,9 +14,14 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 @Mixin(value = ChunkGeneratorMystic.class, remap = false)
 public class MixinChunkGeneratorMystic implements CompatibleChunkGenerator {
+    /* The modified biomes after querying the biome provider */
     @Shadow
     private Biome[] biomesForGeneration;
 
+    /*
+     * Explicit compatibility with REID's biome format.
+     * The chunk generator modifies the biomes returned by the world's biome provider.
+     */
     @Inject(method = "generateChunk", at = @At(value = "RETURN"), remap = true)
     private void reid$initBiomes(CallbackInfoReturnable<Chunk> cir) {
         BiomeApi.INSTANCE.replaceBiomes(cir.getReturnValue(), biomesForGeneration);

--- a/src/main/java/org/dimdev/jeid/mixin/modsupport/warpdrive/MixinSpaceWorldProvider.java
+++ b/src/main/java/org/dimdev/jeid/mixin/modsupport/warpdrive/MixinSpaceWorldProvider.java
@@ -1,0 +1,23 @@
+package org.dimdev.jeid.mixin.modsupport.warpdrive;
+
+import net.minecraft.world.WorldProvider;
+import net.minecraft.world.biome.BiomeProviderSingle;
+
+import cr0s.warpdrive.WarpDrive;
+import cr0s.warpdrive.world.SpaceWorldProvider;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(SpaceWorldProvider.class)
+public abstract class MixinSpaceWorldProvider extends WorldProvider {
+    /*
+     * The biome provider is supposed to be set in init(), but is incorrectly set in the constructor
+     * to then be overwritten by the default provider due to super.init().
+     */
+    @Inject(method = "init", at = @At("TAIL"))
+    private void reid$fixBiomeProvider(CallbackInfo ci) {
+        biomeProvider = new BiomeProviderSingle(WarpDrive.biomeSpace);
+    }
+}

--- a/src/main/java/org/dimdev/jeid/util/Mods.java
+++ b/src/main/java/org/dimdev/jeid/util/Mods.java
@@ -1,9 +1,6 @@
 package org.dimdev.jeid.util;
 
-import net.minecraft.util.ResourceLocation;
-
 import net.minecraftforge.fml.common.Loader;
-import org.dimdev.jeid.JEID;
 
 public enum Mods {
     ADVANCED_ROCKETRY("advancedrocketry"),
@@ -34,16 +31,15 @@ public enum Mods {
     TOFUCRAFT("tofucraft"),
     TROPICRAFT("tropicraft"),
     TWILIGHT_FOREST("twilightforest"),
+    WARP_DRIVE("warpdrive"),
     WORLD_EDIT("worldedit"),
     WYRMS_OF_NYRUS("wyrmsofnyrus"),
     ;
 
     public final String modId;
-    private final ResourceLocation registryKey;
 
     Mods(String modId) {
         this.modId = modId;
-        registryKey = new ResourceLocation(JEID.MODID, modId);
     }
 
     public boolean isLoaded() {

--- a/src/main/java/tff/reid/api/compat/CompatibleChunkGenerator.java
+++ b/src/main/java/tff/reid/api/compat/CompatibleChunkGenerator.java
@@ -3,9 +3,9 @@ package tff.reid.api.compat;
 import net.minecraft.world.gen.IChunkGenerator;
 
 /**
- * Implement this if your mod has a {@link IChunkGenerator} that already provides compatibility with REID's biome format
+ * Implement this if your mod has an {@link IChunkGenerator} that provides custom compatibility with REID's biome format
  * in {@link IChunkGenerator#generateChunk(int, int)}.
- * Not strictly necessary, but will reduce chunk generation overhead from REID.
+ * This is required, otherwise REID will overwrite your changes with its default implementation.
  */
 public interface CompatibleChunkGenerator {
 }

--- a/src/main/resources/mixins.jeid.warpdrive.json
+++ b/src/main/resources/mixins.jeid.warpdrive.json
@@ -1,0 +1,10 @@
+{
+  "package": "org.dimdev.jeid.mixin.modsupport.warpdrive",
+  "required": true,
+  "refmap": "mixins.jeid.refmap.json",
+  "minVersion": "0.8",
+  "compatibilityLevel": "JAVA_8",
+  "mixins": [
+    "MixinSpaceWorldProvider"
+  ]
+}


### PR DESCRIPTION
Fixes a bug in WarpDrive where its space dimension doesn't properly set its own `BiomeProviderSingle`. The bug only happens to not be exhibited in vanilla because WarpDrive [hardcodes](https://github.com/LemADEC/WarpDrive/blob/b691306a71abca73f66f8591235d600a436ea8e6/src/main/java/cr0s/warpdrive/world/SpaceChunkProvider.java#L41-L44) the biome in its chunk provider instead of querying its biome provider.

Closes #90.